### PR TITLE
Fix failing tests

### DIFF
--- a/src/test/kotlin/com/triangl/trackingIngestion/ComputingServiceTest.kt
+++ b/src/test/kotlin/com/triangl/trackingIngestion/ComputingServiceTest.kt
@@ -55,7 +55,6 @@ class ComputingServiceTest {
 
         /* Then */
         val bufferState = computingService.readFromBuffer()
-        assertThat(bufferState.keys.size, `is`(1))
         assertThat(bufferState["DeviceId1"]!!.size, `is`(1))
         assertThat(bufferState["DeviceId1"]!![0].dataPoints.size, `is`(1))
 
@@ -71,7 +70,6 @@ class ComputingServiceTest {
 
         /* Then */
         val bufferState = computingService.readFromBuffer()
-        assertThat(bufferState.keys.size, `is`(1))
         assertThat(bufferState["DeviceId1"]!!.size, `is`(1))
         assertThat(bufferState["DeviceId1"]!![0].dataPoints.size, `is`(3))
 


### PR DESCRIPTION
# What
Fixed failing tests

# How
The local tests run the Integration test and the Unit test after each other.
CircleCi runs the tests simultaneously.
The integration and the unit tests insert Tracking Points with different deviceId's so we can't assert that in the buffer is only one DeviceId