### PR TITLE
Refactored from Instant to LocalDateTime and removed print Statements

### DIFF
--- a/src/main/kotlin/com/triangl/trackingIngestion/TrackingIngestionApplication.kt
+++ b/src/main/kotlin/com/triangl/trackingIngestion/TrackingIngestionApplication.kt
@@ -14,6 +14,7 @@ import org.springframework.integration.annotation.MessagingGateway
 import org.springframework.integration.annotation.ServiceActivator
 import org.springframework.messaging.MessageHandler
 import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 
 
 @Component
@@ -30,7 +31,7 @@ class TrackingIngestionApplication {
         return PubSubMessageHandler(pubsubTemplate, "test")
     }
 
-    @Profile("production")
+    @Service
     @MessagingGateway(defaultRequestChannel = "pubsubOutputChannel")
     interface PubsubOutboundGateway {
 

--- a/src/main/kotlin/com/triangl/trackingIngestion/entity/DatapointGroup.kt
+++ b/src/main/kotlin/com/triangl/trackingIngestion/entity/DatapointGroup.kt
@@ -1,23 +1,17 @@
 package com.triangl.trackingIngestion.entity
 
-import java.time.Instant
+import java.time.LocalDateTime
 import java.util.*
 
 class DatapointGroup (
-        startInstantString: String,
+        startInstant: LocalDateTime,
         var deviceId: String
 ) {
-    var startInstant = Instant.parse(startInstantString)
-                        .minusSeconds(3)
-                        .toString()
+    var startInstant: LocalDateTime = startInstant.minusSeconds(3)
 
-    var endInstant = Instant.parse(startInstantString)
-                         .plusSeconds(3)
-                         .toString()
+    var endInstant: LocalDateTime = startInstant.plusSeconds(3)
 
     var dataPoints = ArrayList<InputDataPoint>()
 
-    var timeoutInstant = Instant.parse(startInstantString)
-                         .plusSeconds(30)
-                         .toString()
+    var timeoutInstant: LocalDateTime = startInstant.plusSeconds(30)
 }

--- a/src/main/kotlin/com/triangl/trackingIngestion/entity/InputDataPoint.kt
+++ b/src/main/kotlin/com/triangl/trackingIngestion/entity/InputDataPoint.kt
@@ -1,13 +1,18 @@
 package com.triangl.trackingIngestion.entity
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 class InputDataPoint (
     var routerId: String,
 
     var deviceId: String,
 
-    var timestamp: String,
+    timestampString: String,
 
     var signalStrength: Int,
 
     var timeOfFlight: Long? = null
-)
+) {
+    var timestamp: LocalDateTime = LocalDateTime.parse(timestampString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+}

--- a/src/main/kotlin/com/triangl/trackingIngestion/webservices/datastore/DatastoreWsMock.kt
+++ b/src/main/kotlin/com/triangl/trackingIngestion/webservices/datastore/DatastoreWsMock.kt
@@ -5,7 +5,7 @@ import com.triangl.trackingIngestion.entity.*
 import com.triangl.trackingIngestion.entity.Map
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
-import java.time.Instant
+import java.time.LocalDateTime
 import java.util.*
 
 @Service
@@ -14,7 +14,7 @@ class DatastoreWsMock: DatastoreWs {
     val router1 = Router(id = "Router1", location = Coordinate(x = 1f, y = 2f))
     val router2 = Router(id = "Router2", location = Coordinate(x = 5f, y = 2f))
     val router3 = Router(id = "Router3", location = Coordinate(x = 3f, y = 5f))
-    val now = Instant.now().toString()
+    val now = LocalDateTime.now().toString()
 
     override fun saveTrackingPoint(trackingPoint: TrackingPoint): Key<TrackingPoint> = Key.create(TrackingPoint::class.java, UUID.randomUUID().toString())
 

--- a/src/test/kotlin/com/triangl/trackingIngestion/ComputingServiceTest.kt
+++ b/src/test/kotlin/com/triangl/trackingIngestion/ComputingServiceTest.kt
@@ -15,7 +15,8 @@ import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import java.time.Instant
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class ComputingServiceWrapper(
     ingestionService: IngestionService,
@@ -37,10 +38,11 @@ class ComputingServiceTest {
     @InjectMocks
     private lateinit var computingService: ComputingServiceWrapper
 
-    private val now = "2018-09-25T13:49:09.404141Z"
-    private val inputDataPoint1 = InputDataPoint("RouterId1", "DeviceId1", now, 255)
-    private val inputDataPoint2 = InputDataPoint("RouterId2", "DeviceId1", now, 200)
-    private val inputDataPoint3 = InputDataPoint("RouterId3", "DeviceId1", now, 180)
+    private val nowString = "2018-09-25 13:49:09"
+    private val now = LocalDateTime.parse(nowString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+    private val inputDataPoint1 = InputDataPoint("RouterId1", "DeviceId1", nowString, 255)
+    private val inputDataPoint2 = InputDataPoint("RouterId2", "DeviceId1", nowString, 200)
+    private val inputDataPoint3 = InputDataPoint("RouterId3", "DeviceId1", nowString, 180)
 
     private val router1 = Router("RouterId1", Coordinate(x = 1f, y = 2f))
     private val router2 = Router("RouterId2", Coordinate(x = 2f, y = 3f))
@@ -119,7 +121,7 @@ class ComputingServiceTest {
         /* Given */
         val incompleteRouter1 = Router(router1.id)
 
-        val routerDataPoint1 = RouterDataPoint(router = incompleteRouter1, timestamp = now)
+        val routerDataPoint1 = RouterDataPoint(router = incompleteRouter1, timestamp = now.toString())
         val routerDataPointList = listOf(routerDataPoint1)
 
         val routerHashMap = hashMapOf(router1.id!! to router1)

--- a/src/test/kotlin/com/triangl/trackingIngestion/TrackingIntegrationTest.kt
+++ b/src/test/kotlin/com/triangl/trackingIngestion/TrackingIntegrationTest.kt
@@ -10,12 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
-import java.time.Instant
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @RunWith(SpringRunner::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-class CustomerIntegrationTest {
+class TrackingIntegrationTest {
 
     @Value("\${local.server.port}")
     private val serverPort: Int = 0
@@ -31,11 +32,11 @@ class CustomerIntegrationTest {
         val routerId = "Router1"
         val deviceId = "Device1"
         val signalStrength = 255
-        val now = Instant.now().toString()
+        val now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
 
         RestAssured.given()
                 .contentType(ContentType.JSON)
-                .body("{ \"deviceId\": \"$deviceId\", \"routerId\": \"$routerId\", \"signalStrength\": \"$signalStrength\", \"timestamp\": \"$now\" }")
+                .body("{ \"deviceId\": \"$deviceId\", \"routerId\": \"$routerId\", \"signalStrength\": \"$signalStrength\", \"timestampString\": \"$now\" }")
                 .post("/tracking")
                 .then()
                 .log().ifValidationFails()
@@ -49,12 +50,12 @@ class CustomerIntegrationTest {
         val routerId = "Router1"
         val deviceId = "Device1"
         val signalStrength = 255
-        val now = Instant.now().toString()
+        val now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
 
         RestAssured.given()
                 .contentType(ContentType.JSON)
-                .body("[{ \"deviceId\": \"$deviceId\", \"routerId\": \"$routerId\", \"signalStrength\": \"$signalStrength\", \"timestamp\": \"$now\" }," +
-                            " { \"deviceId\": \"$deviceId\", \"routerId\": \"$routerId\", \"signalStrength\": \"$signalStrength\", \"timestamp\": \"$now\" }]")
+                .body("[{ \"deviceId\": \"$deviceId\", \"routerId\": \"$routerId\", \"signalStrength\": \"$signalStrength\", \"timestampString\": \"$now\" }," +
+                            " { \"deviceId\": \"$deviceId\", \"routerId\": \"$routerId\", \"signalStrength\": \"$signalStrength\", \"timestampString\": \"$now\" }]")
                 .post("/tracking/multiple")
                 .then()
                 .log().ifValidationFails()


### PR DESCRIPTION
# What
- The Service now needs InputDataPoints from the Routers with timestamps in the format of '2018-10-10 19:16:35' which is the easiest format for them
- Removed some print Statements