### PR TITLE
Changed buffer type to a thread safe type

### DIFF
--- a/src/main/kotlin/com/triangl/trackingIngestion/service/ComputingService.kt
+++ b/src/main/kotlin/com/triangl/trackingIngestion/service/ComputingService.kt
@@ -8,8 +8,9 @@ import kotlinx.coroutines.experimental.launch
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import java.util.concurrent.ConcurrentHashMap
 
-var buffer = HashMap<String, ArrayList<DatapointGroup>>()
+var buffer = ConcurrentHashMap<String, ArrayList<DatapointGroup>>()
 
 @Service("computingService")
 class ComputingService (


### PR DESCRIPTION
# What
Changed global Buffer type to a MultiThread safe type, because with our two threads we cause an ConcurrentModificationException